### PR TITLE
Updated batchsize mandatory value in jobs that were empty batch

### DIFF
--- a/courier-job-examples/create-job-simple.json
+++ b/courier-job-examples/create-job-simple.json
@@ -8,7 +8,10 @@
     "groups":[
       {
         "timeoutSeconds": 240,
-        "batchSize": {},
+        "batchSize": {
+           "type": "number",
+           "value": 1
+            },
         "distributionMethod": "batching",
         "successCriteria": [
           {

--- a/courier-job-examples/infra_client_local.json
+++ b/courier-job-examples/infra_client_local.json
@@ -8,7 +8,10 @@
     "groups":[
       {
         "timeoutSeconds": 240,
-        "batchSize": {},
+        "batchSize": {
+           "type": "number",
+           "value": 1
+            },
         "distributionMethod": "batching",
         "successCriteria": [
           {

--- a/courier-job-examples/infra_client_pem_key_rotation.json
+++ b/courier-job-examples/infra_client_pem_key_rotation.json
@@ -8,7 +8,10 @@
     "groups":[
       {
         "timeoutSeconds": 240,
-        "batchSize": {},
+        "batchSize": {
+           "type": "number",
+           "value": 1
+            },
         "distributionMethod": "batching",
         "successCriteria": [
           {

--- a/courier-job-examples/infra_client_run.json
+++ b/courier-job-examples/infra_client_run.json
@@ -8,7 +8,10 @@
     "groups":[
       {
         "timeoutSeconds": 240,
-        "batchSize": {},
+        "batchSize": {
+           "type": "number",
+           "value": 1
+            },
         "distributionMethod": "batching",
         "successCriteria": [
           {

--- a/courier-job-examples/inspec_exec.json
+++ b/courier-job-examples/inspec_exec.json
@@ -8,7 +8,10 @@
     "groups": [
       {
         "timeoutSeconds": 120,
-        "batchSize": {},
+        "batchSize": {
+           "type": "number",
+           "value": 1
+            },
         "distributionMethod": "batching",
         "successCriteria": [
           {

--- a/courier-job-examples/inspec_with_token.json
+++ b/courier-job-examples/inspec_with_token.json
@@ -8,7 +8,10 @@
       "groups": [
         {
           "timeoutSeconds": 120,
-          "batchSize": {},
+          "batchSize": {
+           "type": "number",
+           "value": 1
+            },
           "distributionMethod": "batching",
           "successCriteria": [
             {

--- a/courier-job-examples/ssl_cert_rotation.json
+++ b/courier-job-examples/ssl_cert_rotation.json
@@ -8,7 +8,10 @@
       "groups": [
         {
           "timeoutSeconds": 120,
-          "batchSize": {},
+          "batchSize": {
+           "type": "number",
+           "value": 1
+            },
           "distributionMethod": "batching",
           "successCriteria": [
             {


### PR DESCRIPTION
Batch size is mandatory in jobs now. Have updated the sample courier jobs that had an empty batch size with size as 1

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
