### PR TITLE
Rename default skill assembly

### DIFF
--- a/cohorts/skill-assembly.json
+++ b/cohorts/skill-assembly.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-skill-assembly",
+  "name": "sample-skill-assembly",
   "skills": [
     {
       "action": "add",


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

This renames the skill assembly so it matches the default skill assembly name: `sample-skill-assembly`.

See this related PR: https://github.com/progress-platform-services/chef-web-docs/pull/439



## Related Issue

- https://progresssoftware.atlassian.net/browse/CHEF-20494

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
