### PR TITLE
CHEF-27197 - Create CONTRIBUTING.md file with standard template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing to a Chef Project
+
+Thank you for your interest in contributing to this project! It is part of the larger Progress ecosystem of projects but is governed by the Chef Client contribution guidelines, which may be found at [Contributing to Progress Chef Infra Client](https://chef.github.io/chef-oss-practices/projects/chef/contributing/).


### PR DESCRIPTION
This pull request creates CONTRIBUTING.md file with the standard template.  As part of the [repo standardization effort](https://github.com/chef-boneyard/oss-repo-standardization-2025) we are replacing all the different contributing guides with a standard template that links to a published version of the chef-oss-practices repo.
This PR is intended to be a mere mechanical change, not a change in policy. Watch chef/chef-oss-practices for changes in policy. 